### PR TITLE
feat: Update the hello-android application for the new feature in 5.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:4.2.2'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.0.0'
 
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/app/src/main/java/com/launchdarkly/hello_android/MainActivity.kt
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainActivity.kt
@@ -10,7 +10,7 @@ import com.launchdarkly.sdk.android.LDClient
 class MainActivity : AppCompatActivity() {
 
     // Set BOOLEAN_FLAG_KEY to the feature flag key you want to evaluate.
-    val BOOLEAN_FLAG_KEY = "first-flag-in-ld"
+    val BOOLEAN_FLAG_KEY = "my-boolean-flag"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/launchdarkly/hello_android/MainActivity.kt
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainActivity.kt
@@ -10,7 +10,7 @@ import com.launchdarkly.sdk.android.LDClient
 class MainActivity : AppCompatActivity() {
 
     // Set BOOLEAN_FLAG_KEY to the feature flag key you want to evaluate.
-    val BOOLEAN_FLAG_KEY = "my-boolean-flag"
+    val BOOLEAN_FLAG_KEY = "first-flag-in-ld"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
@@ -12,7 +12,7 @@ class MainApplication : Application() {
     companion object {
 
         // Set LAUNCHDARKLY_MOBILE_KEY to your LaunchDarkly SDK mobile key.
-        const val LAUNCHDARKLY_MOBILE_KEY = "mob-3924cdf5-2e4f-4385-baf2-e9e12905c9fc"
+        const val LAUNCHDARKLY_MOBILE_KEY = "mobile-key-from-launch-darkly-website"
     }
 
     override fun onCreate() {

--- a/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
@@ -5,13 +5,14 @@ import com.launchdarkly.sdk.ContextKind
 import com.launchdarkly.sdk.LDContext
 import com.launchdarkly.sdk.android.LDClient
 import com.launchdarkly.sdk.android.LDConfig
+import com.launchdarkly.sdk.android.LDConfig.Builder.AutoEnvAttributes
 
 class MainApplication : Application() {
 
     companion object {
 
         // Set LAUNCHDARKLY_MOBILE_KEY to your LaunchDarkly SDK mobile key.
-        const val LAUNCHDARKLY_MOBILE_KEY = "mobile-key-from-launch-darkly-website"
+        const val LAUNCHDARKLY_MOBILE_KEY = "mob-3924cdf5-2e4f-4385-baf2-e9e12905c9fc"
     }
 
     override fun onCreate() {
@@ -19,7 +20,9 @@ class MainApplication : Application() {
 
         // Set LAUNCHDARKLY_MOBILE_KEY to your LaunchDarkly mobile key found on the LaunchDarkly
         // dashboard in the start guide.
-        val ldConfig = LDConfig.Builder()
+        // If you want to disable the Auto EnvironmentAttributes functionality.
+        // Use AutoEnvAttributes.Disabled as the argument to the Builder
+        val ldConfig = LDConfig.Builder(AutoEnvAttributes.Enabled)
             .mobileKey(LAUNCHDARKLY_MOBILE_KEY)
             .build()
 


### PR DESCRIPTION
Do not merge until we release the actual 5.0.0 SDK. If we need to do multiple 5.x releases, we will need to update this to reflect the latest SDK version number.

I think the breaking change is in the builder args, we can verify that once we release this.