### PR TITLE
chore: Update Android SDK from 5.11.0 to 5.11.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.11.0'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.11.1'
 
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'


### PR DESCRIPTION
## Summary
Bumps the LaunchDarkly Android Client SDK dependency from `5.11.0` to `5.11.1` (patch release).

## Review & Testing Checklist for Human
- [x] Verify `5.11.1` is the latest desired version of `launchdarkly-android-client-sdk`
- [ ] Build and run the example app on an emulator or device to confirm it still connects and evaluates flags correctly

### Notes
- Single-line change in `app/build.gradle`; no README update needed as it does not reference the SDK version
- No Gradle lock file to update (not committed in this repo)

Link to Devin session: https://app.devin.ai/sessions/707962703f2540d5b8c92734ecf9e33a
Requested by: @kinyoklion