### PR TITLE
chore: update Android SDK from 5.12.0 to 5.12.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.12.0'
+    implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.12.2'
 
     implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'


### PR DESCRIPTION
## Summary

Bumps `launchdarkly-android-client-sdk` from 5.12.0 to 5.12.2 in `app/build.gradle`.

Link to Devin session: https://app.devin.ai/sessions/d0545f9be7594100bb281ceb0584d2ae
Requested by: @kinyoklion