### PR TITLE
chore: update AGP to 9.2.1, compileSdk to 37, and core-ktx to 1.19.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,9 +22,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,10 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
 }
 
 android {
     namespace "com.launchdarkly.hello_android"
-    compileSdk 34
+    compileSdk 37
     defaultConfig {
         applicationId "com.launchdarkly.hello_android"
         minSdkVersion(24)
@@ -31,6 +30,6 @@ android {
 dependencies {
     implementation 'com.launchdarkly:launchdarkly-android-client-sdk:5.12.2'
 
-    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.core:core-ktx:1.19.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-        id 'com.android.application' version '8.7.0' apply false
-        id 'com.android.library' version '8.7.0' apply false
-        id 'org.jetbrains.kotlin.android' version '2.4.0' apply false
+        id 'com.android.application' version '9.2.1' apply false
+        id 'com.android.library' version '9.2.1' apply false
 }


### PR DESCRIPTION
## Summary

Combined dependency update that supersedes Dependabot PRs #22, #25, and #26, which could not be applied individually due to interdependencies.

AGP 9.x migration changes:
- Android Gradle Plugin `8.7.0` → `9.2.1`
- Remove `org.jetbrains.kotlin.android` plugin (built into AGP 9+)
- Remove `kotlinOptions` block (now inferred from `compileOptions`)
- Switch to `proguard-android-optimize.txt` (`proguard-android.txt` removed in AGP 9)

Dependency updates enabled by AGP 9:
- `compileSdk` `34` → `37` (required by core-ktx 1.19.0)
- `androidx.core:core-ktx` `1.10.1` → `1.19.0`

Link to Devin session: https://app.devin.ai/sessions/e2ff3da9b9514c4db97772ec4d9db35c
Requested by: @kinyoklion