### PR TITLE
ci: remove duplicate gradle dependabot entry for /app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,4 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-  - package-ecosystem: "gradle"
-    directory: "/app"
-    schedule:
-      interval: "weekly"
-    cooldown:
-      default-days: 7
+


### PR DESCRIPTION
## Summary

The `dependabot.yml` had two `gradle` ecosystem entries — one for `/` and one for `/app`. Since the root `/` entry scans the entire Gradle project including subprojects, both entries discovered the same `launchdarkly-android-client-sdk` dependency in `app/build.gradle`, producing duplicate PRs (#29 and #30) for the same version bump.

Removes the redundant `/app` entry so only the root-level entry remains.

Link to Devin session: https://app.devin.ai/sessions/abb872ed8f024de08652a0e4bd201f43
Requested by: @kinyoklion