### PR TITLE
chore: replace deprecated LDClient.init() with timeout variant

### DIFF
--- a/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
+++ b/app/src/main/java/com/launchdarkly/hello_android/MainApplication.kt
@@ -38,7 +38,7 @@ class MainApplication : Application() {
                 .build()
         }
 
-        LDClient.init(this@MainApplication, ldConfig, context)
+        LDClient.init(this@MainApplication, ldConfig, context, 5)
     }
 
     private fun isUserLoggedIn(): Boolean = false


### PR DESCRIPTION
## Summary

`LDClient.init(Application, LDConfig, LDContext)` (no timeout) was deprecated in SDK 5.2.0. Replaced with the timeout overload:

```diff
- LDClient.init(this@MainApplication, ldConfig, context)
+ LDClient.init(this@MainApplication, ldConfig, context, 5)
```

Uses a 5-second startup wait, consistent with the SDK's recommended usage pattern. The SDK version (5.13.1) is already at the latest stable release — no dependency bump needed.

Link to Devin session: https://app.devin.ai/sessions/ade60c53c28c4ebaa7f9ad394c3dcd9d
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line SDK API migration in app startup with no auth or data-model changes.
> 
> **Overview**
> Replaces the deprecated no-timeout **`LDClient.init(Application, LDConfig, LDContext)`** call in **`MainApplication.onCreate`** with the timeout overload, passing **5** seconds so startup can wait for the client to be ready per current SDK guidance.
> 
> No other init sites or dependency changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 117b49d417edba37657906d6ba15cd96918a92e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->